### PR TITLE
Add Folia compatibility for scheduler operations

### DIFF
--- a/src/main/java/net/milkbowl/vault/util/UpdateUtil.java
+++ b/src/main/java/net/milkbowl/vault/util/UpdateUtil.java
@@ -50,8 +50,7 @@ public class UpdateUtil {
      */
     public static void checkForUpdates() {
         Vault plugin = Vault.getInstance();
-
-        Bukkit.getScheduler().runTaskAsynchronously(plugin, () -> {
+        Runnable task = () -> {
             @Nullable String latestVersion = getLatestReleaseVersion();
             @NotNull String currentVersion = plugin.getDescription().getVersion();
 
@@ -65,7 +64,14 @@ public class UpdateUtil {
             } else {
                 MessageUtil.log(Level.WARNING, "Failed to fetch the latest release version.");
             }
-        });
+        };
+
+        try {
+            Bukkit.getScheduler().runTaskAsynchronously(plugin, task);
+        } catch (UnsupportedOperationException ex) {
+            // Fallback for Folia-like servers that do not support the legacy scheduler.
+            task.run();
+        }
     }
 
     /**


### PR DESCRIPTION
**Checklist**

- [x] I have read the [Contribution Guidelines](CONTRIBUTING.md).
- [x] I have searched the issue tracker for a similar issue.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have performed a self-review of my code.
- [x] My changes generate no new warnings or errors.

**Related Issue(s)**
No issues opened, detected by me

**Change(s) Made**
Added folia compatibility for scheduler operations

## Summary by Sourcery

Add compatibility with Folia-style servers by making scheduler usage tolerant of missing legacy scheduler support.

Bug Fixes:
- Prevent plugin disable from failing when the Bukkit scheduler is unavailable on Folia-style servers.

Enhancements:
- Guard update-check scheduling and task cancellation with fallbacks when the legacy Bukkit scheduler is not supported.
- Run the update check asynchronously via CompletableFuture when the legacy scheduler is unavailable, and synchronously as a last-resort fallback in the update utility.